### PR TITLE
Fix: Error permission error while git submodule update --remote.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "necpp_src"]
 	path = necpp_src
-	url = git@github.com:tmolteno/necpp
+	url = https://github.com/tmolteno/necpp.git


### PR DESCRIPTION
I was trying to build the python-necpp. So I got this error while updating the submodule necpp.
In .gitmodules, changed the git ssh to git https necpp module for public use.
