### PR TITLE
Added pyproject.toml 

### DIFF
--- a/PyNEC/pyproject.toml
+++ b/PyNEC/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Because installing PyNEC requires Numpy to be present on the system before, it can be an issue on some builds systems, for example with ReadTheDocs which allows only a single requirements.txt, and pip does not follow the order of packages when installing.

This is addressed in [PEP 518](https://www.python.org/dev/peps/pep-0518/) with a pyproject.toml file specifying the minimum build requirements. This is what this PR adds.